### PR TITLE
Modernize setup and packaging.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+  'setuptools >= 42',
+  'wheel',
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = PYSCSI
+version = 1.0
+description = Module for calling SCSI devices from Python
+url = https://github.com/python-scsi/python-scsi
+license_files =
+   LICENSE
+license = LGPL-2.1+
+long_description = file:README.md
+long_description_content_type: text/markdown
+maintainer = Markus Rosjat
+maintainer_email = markus.rosjat@gmail.com
+keywords =
+    scsi
+classifiers =
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 # lets prepare our initial setup
 setup_dict = {'name': 'PYSCSI',
@@ -9,7 +9,7 @@ setup_dict = {'name': 'PYSCSI',
               'author': 'Ronnie Sahlberg',
               'author_email': 'ronniesahlberg@gmail.com',
               'description': 'Module for calling SCSI devices from Python',
-              'packages': ['pyscsi', 'pyscsi.pyscsi', 'pyscsi.pyiscsi', 'pyscsi.utils'],
+              'packages': find_packages(),
               'python_requires': '~=3.7',
               'extras_require': {'sgio': ['cython-sgio'],
                                  'iscsi': ['cython-iscsi'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from distutils.core import setup
+from setuptools import setup
 
 # lets prepare our initial setup
 setup_dict = {'name': 'PYSCSI',

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@
 
 from setuptools import find_packages, setup
 
-# lets prepare our initial setup
-setup_dict = {'packages': find_packages(),
-              'python_requires': '~=3.7',
-              'extras_require': {'sgio': ['cython-sgio'],
-                                 'iscsi': ['cython-iscsi'],
-                                 },
-              }
-
-setup(**setup_dict)
+setup(
+    packages=find_packags(),
+    python_requires='~=3.7',
+    extras_require={
+        'sgio': ['cython-sgio'],
+        'iscsi': ['cython-iscsi'],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,7 @@
 from setuptools import find_packages, setup
 
 # lets prepare our initial setup
-setup_dict = {'name': 'PYSCSI',
-              'version': '1.0',
-              'license': 'LGPLv2.1',
-              'author': 'Ronnie Sahlberg',
-              'author_email': 'ronniesahlberg@gmail.com',
-              'description': 'Module for calling SCSI devices from Python',
-              'packages': find_packages(),
+setup_dict = {'packages': find_packages(),
               'python_requires': '~=3.7',
               'extras_require': {'sgio': ['cython-sgio'],
                                  'iscsi': ['cython-iscsi'],


### PR DESCRIPTION
This should make it easier to build PyPI packages for the module.

Note that this does not (yet) include `setuptools_scm` to wire in the auto-versioning, which I would recommend. The reason for that is that it would require tagging a commit as 2.0.0-alpha to make sure that the next release is properly defined as 2.0.0 when tagging it final.
