### PR TITLE
Add a minimum cython-sgio version to the dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
             'wheel',
         ],
         'iscsi': ['cython-iscsi'],
-        'sgio': ['cython-sgio'],
+        'sgio': ['cython-sgio>=1.1.2'],
     },
 )


### PR DESCRIPTION
This makes sure that only the _fixed_ cython-sgio version is used.

I think that after this it would be a good time to release PYSCSI-2.0.0.