### PR TITLE
Use setup-cfg-fmt to provide a more standardized setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,28 +5,26 @@
 [metadata]
 name = PYSCSI
 description = Module for calling SCSI devices from Python
-url = https://github.com/python-scsi/python-scsi
-license_files =
-   LICENSES/*
-license = LGPL-2.1+
-long_description = file:README.md
+long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/python-scsi/python-scsi
 maintainer = Markus Rosjat
 maintainer_email = markus.rosjat@gmail.com
-keywords =
-    scsi
+license = LGPL-2.1
+license_file = LICENSE
+license_files =
+    LICENSES/*
 classifiers =
+    License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
     Programming Language :: Python
     Programming Language :: Python :: 3
-    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+keywords =
+    scsi
 
 [options]
-python_requires = ~= 3.7
 packages = find:
-
-[options.packages.find]
-exclude =
-    tests
+python_requires = ~= 3.7
 
 [options.extras_require]
 dev =
@@ -38,5 +36,11 @@ dev =
     setuptools>=42
     setuptools_scm[toml]>=3.4
     wheel
-iscsi = cython-iscsi
-sgio = cython-sgio>=1.1.2
+iscsi =
+    cython-iscsi
+sgio =
+    cython-sgio>=1.1.2
+
+[options.packages.find]
+exclude =
+    tests


### PR DESCRIPTION
This maintains the SPDX headers.