### PR TITLE
READCD: add full unmarshalling of datain

### DIFF
--- a/pyscsi/pyscsi/scsi.py
+++ b/pyscsi/pyscsi/scsi.py
@@ -502,6 +502,7 @@ class SCSI(object):
                      tl,
                      **kwargs)
         self.execute(cmd)
+        cmd.unmarshall(lba=lba, tl=tl, **kwargs)
         return cmd
 
     def readdiscinformation(self,

--- a/pyscsi/pyscsi/scsi_enum_readcd.py
+++ b/pyscsi/pyscsi/scsi_enum_readcd.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# coding: utf-8
+
+
+from pyscsi.utils.enum import Enum
+
+#
+# EXPECTED_SECTOR_TYPE
+#
+_expected_sector_type = {'CDDA': 1,
+                         'MODE_1': 2,
+                         'MODE_2_FORMLESS': 3,
+                         'MODE_2_FORM_1': 4,
+                         'MODE_2_FORM_2': 5, }
+
+EXPECTED_SECTOR_TYPE = Enum(_expected_sector_type)


### PR DESCRIPTION
We used to just return the datain blob to the application and have it do the unmarshalling. Change that so that we do the unmarshalling in the scsi code instead so we don't have to re-invent the wheel for every application using READCD.

Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>