### PR TITLE
enable to get raw_sense_data in

### DIFF
--- a/pyscsi/pyscsi/scsi.py
+++ b/pyscsi/pyscsi/scsi.py
@@ -98,14 +98,14 @@ class SCSI(object):
             elif self.device.devicetype in (0x05,):  # mmc
                 self.device.opcodes = mmc
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense=False):
         """
         wrapper method to call the SCSIDevice.execute method
 
         :param cmd: a SCSICommand object
         """
         try:
-            self.device.execute(cmd)
+            self.device.execute(cmd, en_raw_sense=en_raw_sense)
         except Exception as e:
             raise e
 
@@ -772,6 +772,7 @@ class SCSI(object):
                          count,
                          lba,
                          command,
+                         en_raw_sense=False,
                          **kwargs):
         """
         Return a ATAPassThrough12 Instance, check ATA Status Return Descriptor by yourself
@@ -786,6 +787,7 @@ class SCSI(object):
         :param count: ATAPassThrough12 count field
         :param lba: ATAPassThrough12 lba field
         :param command: ATAPassThrough12 command field
+        :param en_raw_sense=False: Flags to enable raw_sense_data
         :param kwargs: a dict with key/value pairs
                        blocksize=None: a blocksize
                        extra_tl=None, if t_length=3, can fix the transfer length in this option
@@ -808,7 +810,7 @@ class SCSI(object):
                                lba,
                                command,
                                **kwargs)
-        self.execute(cmd)
+        self.execute(cmd, en_raw_sense=en_raw_sense)
         return cmd
 
     def atapassthrough16(self,
@@ -822,6 +824,7 @@ class SCSI(object):
                          count,
                          lba,
                          command,
+                         en_raw_sense=False,
                          **kwargs):
         """
         Return a ATAPassThrough16 Instance, check ATA Status Return Descriptor by yourself
@@ -836,6 +839,7 @@ class SCSI(object):
         :param count: ATAPassThrough16 count field
         :param lba: ATAPassThrough16 lba field
         :param command: ATAPassThrough16 command field
+        :param en_raw_sense=False: Flags to enable raw_sense_data
         :param kwargs: a dict with key/value pairs
                        blocksize=None: a blocksize
                        extra_tl=None, if t_length=3, can fix the transfer length in this option
@@ -859,5 +863,5 @@ class SCSI(object):
                                lba,
                                command,
                                **kwargs)
-        self.execute(cmd)
+        self.execute(cmd, en_raw_sense=True)
         return cmd

--- a/pyscsi/pyscsi/scsi.py
+++ b/pyscsi/pyscsi/scsi.py
@@ -772,7 +772,6 @@ class SCSI(object):
                          count,
                          lba,
                          command,
-                         en_raw_sense=False,
                          **kwargs):
         """
         Return a ATAPassThrough12 Instance, check ATA Status Return Descriptor by yourself
@@ -787,7 +786,6 @@ class SCSI(object):
         :param count: ATAPassThrough12 count field
         :param lba: ATAPassThrough12 lba field
         :param command: ATAPassThrough12 command field
-        :param en_raw_sense=False: Flags to enable raw_sense_data
         :param kwargs: a dict with key/value pairs
                        blocksize=None: a blocksize
                        extra_tl=None, if t_length=3, can fix the transfer length in this option
@@ -810,7 +808,7 @@ class SCSI(object):
                                lba,
                                command,
                                **kwargs)
-        self.execute(cmd, en_raw_sense=en_raw_sense)
+        self.execute(cmd, en_raw_sense=True)
         return cmd
 
     def atapassthrough16(self,
@@ -824,7 +822,6 @@ class SCSI(object):
                          count,
                          lba,
                          command,
-                         en_raw_sense=False,
                          **kwargs):
         """
         Return a ATAPassThrough16 Instance, check ATA Status Return Descriptor by yourself
@@ -839,7 +836,6 @@ class SCSI(object):
         :param count: ATAPassThrough16 count field
         :param lba: ATAPassThrough16 lba field
         :param command: ATAPassThrough16 command field
-        :param en_raw_sense=False: Flags to enable raw_sense_data
         :param kwargs: a dict with key/value pairs
                        blocksize=None: a blocksize
                        extra_tl=None, if t_length=3, can fix the transfer length in this option

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -112,7 +112,7 @@ class SCSIDevice(metaclass=ExMETA):
     def close(self):
         self._file.close()
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense=False):
         """
         execute a scsi command
 
@@ -129,7 +129,8 @@ class SCSIDevice(metaclass=ExMETA):
                 self._file,
                 cmd.cdb,
                 cmd.dataout,
-                cmd.datain)
+                cmd.datain,
+                return_sense_buffer=en_raw_sense)
         except sgio.CheckConditionError as error:
             self.CheckCondition(error.sense)
 

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -125,14 +125,21 @@ class SCSIDevice(metaclass=ExMETA):
                 self.open()
 
         try:
+            # TODO: If exist the corner case that sense cannot be raised by error.sense?
+            # will not set return_sense_data=True until i test most of the ata command set.
             sgio.execute(
                 self._file,
                 cmd.cdb,
                 cmd.dataout,
-                cmd.datain,
-                return_sense_buffer=en_raw_sense)
+                cmd.datain)
         except sgio.CheckConditionError as error:
             self.CheckCondition(error.sense)
+            # For ata-passthrough, mostly the scsi command return no real error, here
+            # save the raw sense data to command.raw_sense_data for upper level use.
+            # If you execute the other scsi commands with en_raw_sense=True, this will
+            # be a coppy of error.sense
+            if en_raw_sense:
+                cmd.raw_sense_data = error.sense
 
     @property
     def opcodes(self):


### PR DESCRIPTION
enable to get raw_sense_data in scsi_device.py and scsi.py.

ATA command set under test:
GET NATIVE MAX ADDRESS EXT, CHECK POWER MODE, DATA SET MANAGEMENT,
FLUSH CACHE EXT, IDENTIFY DEVICE, READ DMA, WRITE DMA, 