### PR TITLE
Add optional initiator_name parameter.

### DIFF
--- a/pyscsi/pyiscsi/iscsi_device.py
+++ b/pyscsi/pyiscsi/iscsi_device.py
@@ -36,16 +36,19 @@ class ISCSIDevice(metaclass=ExMETA):
     """
 
     def __init__(self,
-                 device):
+                 device,
+                 initiator_name=None):
         """
         initialize a  new instance of a ISCSIDevice
 
         :param device: a url string
+        :param initiator_name: an initiator_name string
         """
         self._opcodes = scsi_enum_command.spc
         self._file_name = device
         self._iscsi = None
         self._iscsi_url = None
+        self._initiator_name = initiator_name
         if _has_iscsi and device[:8] == 'iscsi://':
             self.open(device)
         else:
@@ -72,7 +75,10 @@ class ISCSIDevice(metaclass=ExMETA):
         """
 
         """
-        self._iscsi = iscsi.Context(device)
+        if self._initiator_name:
+            self._iscsi = iscsi.Context(self._initiator_name)
+        else:
+            self._iscsi = iscsi.Context(device)
         self._iscsi_url = iscsi.URL(self._iscsi, self._file_name)
         self._iscsi.set_targetname(self._iscsi_url.target)
         self._iscsi.set_session_type(iscsi.ISCSI_SESSION_NORMAL)

--- a/pyscsi/pyiscsi/iscsi_device.py
+++ b/pyscsi/pyiscsi/iscsi_device.py
@@ -37,7 +37,7 @@ class ISCSIDevice(metaclass=ExMETA):
 
     def __init__(self,
                  device,
-                 initiator_name=None):
+                 initiator_name=""):
         """
         initialize a  new instance of a ISCSIDevice
 
@@ -75,7 +75,7 @@ class ISCSIDevice(metaclass=ExMETA):
         """
 
         """
-        if self._initiator_name:
+        if len(self._initiator_name):
             self._iscsi = iscsi.Context(self._initiator_name)
         else:
             self._iscsi = iscsi.Context(device)

--- a/pyscsi/utils/__init__.py
+++ b/pyscsi/utils/__init__.py
@@ -4,9 +4,10 @@
 
 from .converter import *
 from .enum import *
+import socket
 
 
-def init_device(dev, read_write=False, initiator_name=None):
+def init_device(dev, read_write=False, initiator_name=f"iqn.2018-01.org.pyscsi:{socket.gethostname()}"):
     if dev[:5] == '/dev/':
         from pyscsi.pyscsi.scsi_device import SCSIDevice
         device = SCSIDevice(dev, read_write)

--- a/pyscsi/utils/__init__.py
+++ b/pyscsi/utils/__init__.py
@@ -6,13 +6,13 @@ from .converter import *
 from .enum import *
 
 
-def init_device(dev, read_write=False):
+def init_device(dev, read_write=False, initiator_name=None):
     if dev[:5] == '/dev/':
         from pyscsi.pyscsi.scsi_device import SCSIDevice
         device = SCSIDevice(dev, read_write)
     elif dev[:8] == 'iscsi://':
         from pyscsi.pyiscsi.iscsi_device import ISCSIDevice
-        device = ISCSIDevice(dev)
+        device = ISCSIDevice(dev, initiator_name)
     else:
         raise NotImplementedError('No backend implemented for %s' % dev)
     return device

--- a/pyscsi/utils/__init__.py
+++ b/pyscsi/utils/__init__.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import socket
+
 from .converter import *
 from .enum import *
 
 
-def init_device(dev, read_write=False, initiator_name=""):
+def init_device(dev, read_write=False, initiator_name=f"iqn.2018-01.org.pyscsi:{socket.gethostname()}"):
     if dev[:5] == '/dev/':
         from pyscsi.pyscsi.scsi_device import SCSIDevice
         device = SCSIDevice(dev, read_write)

--- a/pyscsi/utils/__init__.py
+++ b/pyscsi/utils/__init__.py
@@ -4,10 +4,9 @@
 
 from .converter import *
 from .enum import *
-import socket
 
 
-def init_device(dev, read_write=False, initiator_name=f"iqn.2018-01.org.pyscsi:{socket.gethostname()}"):
+def init_device(dev, read_write=False, initiator_name=""):
     if dev[:5] == '/dev/':
         from pyscsi.pyscsi.scsi_device import SCSIDevice
         device = SCSIDevice(dev, read_write)


### PR DESCRIPTION
Add an _optional_ `initiator_name` parameter to `init_device` and `ISCSIDevice` (in such a manner as to preserve existing behavior if not supplied).

The underlying `libiscsi.iscsi_create_context` expects an `initiator_name` as a parameter.