### PR TITLE
fixing the tests that got broken by 966cef1

### DIFF
--- a/tests/mock_device.py
+++ b/tests/mock_device.py
@@ -12,10 +12,9 @@ class MockSCSI(SCSI):
 
     def __init__(self, dev):
         self.device = dev
-        pass
 
 
-class MockDevice(object):
+class MockDevice:
     _opcodes = None
 
     def __init__(self, opcodes):
@@ -29,7 +28,7 @@ class MockDevice(object):
     def opcodes(self, value):
         self._opcodes = value
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         pass
 
     def open(self):

--- a/tests/test_cdb_exchangemedium.py
+++ b/tests/test_cdb_exchangemedium.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_exchangemedium import ExchangeMedium
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbExchangemediumTest(unittest.TestCase):

--- a/tests/test_cdb_getlbastatus.py
+++ b/tests/test_cdb_getlbastatus.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_getlbastatus import GetLBAStatus
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbGetlbastatusTest(unittest.TestCase):

--- a/tests/test_cdb_initelementstatus.py
+++ b/tests/test_cdb_initelementstatus.py
@@ -11,7 +11,7 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_initelementstatus import InitializeElementStatus
 from pyscsi.pyscsi.scsi_enum_command import smc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbInitelementstatusTest(unittest.TestCase):

--- a/tests/test_cdb_initelementstatuswithrange.py
+++ b/tests/test_cdb_initelementstatuswithrange.py
@@ -14,7 +14,7 @@ from pyscsi.pyscsi.scsi_cdb_initelementstatuswithrange import (
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockInitializeElementStatusWithRange(MockDevice):

--- a/tests/test_cdb_inquiry.py
+++ b/tests/test_cdb_inquiry.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_inquiry import Inquiry
 from pyscsi.pyscsi.scsi_enum_command import spc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbInquiryTest(unittest.TestCase):

--- a/tests/test_cdb_modesense10.py
+++ b/tests/test_cdb_modesense10.py
@@ -13,7 +13,7 @@ from pyscsi.pyscsi.scsi_cdb_modesense10 import ModeSense10
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbModesense10Test(unittest.TestCase):

--- a/tests/test_cdb_modesense6.py
+++ b/tests/test_cdb_modesense6.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi import scsi_enum_modesense as MODESENSE6
 from pyscsi.pyscsi.scsi_cdb_modesense6 import ModeSense6
 from pyscsi.pyscsi.scsi_enum_command import spc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbModesense6Test(unittest.TestCase):

--- a/tests/test_cdb_movemedium.py
+++ b/tests/test_cdb_movemedium.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_movemedium import MoveMedium
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbMovemediumTest(unittest.TestCase):

--- a/tests/test_cdb_openclose_exportimport_element.py
+++ b/tests/test_cdb_openclose_exportimport_element.py
@@ -14,7 +14,7 @@ from pyscsi.pyscsi.scsi_cdb_openclose_exportimport_element import (
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbOpencloseExportimportElementTest(unittest.TestCase):

--- a/tests/test_cdb_positiontoelement.py
+++ b/tests/test_cdb_positiontoelement.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_positiontoelement import PositionToElement
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbPositiontoelementTest(unittest.TestCase):

--- a/tests/test_cdb_preventallow_mediumremoval.py
+++ b/tests/test_cdb_preventallow_mediumremoval.py
@@ -11,7 +11,7 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_preventallow_mediumremoval import PreventAllowMediumRemoval
 from pyscsi.pyscsi.scsi_enum_command import smc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbPreventallowMediumremovalTest(unittest.TestCase):

--- a/tests/test_cdb_read10.py
+++ b/tests/test_cdb_read10.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_read10 import Read10
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbRead10Test(unittest.TestCase):

--- a/tests/test_cdb_read12.py
+++ b/tests/test_cdb_read12.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_read12 import Read12
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbRead12Test(unittest.TestCase):

--- a/tests/test_cdb_read16.py
+++ b/tests/test_cdb_read16.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_read16 import Read16
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbRead16Test(unittest.TestCase):

--- a/tests/test_cdb_readcapacity10.py
+++ b/tests/test_cdb_readcapacity10.py
@@ -11,7 +11,7 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_readcapacity10 import ReadCapacity10
 from pyscsi.pyscsi.scsi_enum_command import sbc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbReadcapacity10Test(unittest.TestCase):

--- a/tests/test_cdb_readcapacity16.py
+++ b/tests/test_cdb_readcapacity16.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_readcapacity16 import ReadCapacity16
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbReadcapacity16Test(unittest.TestCase):

--- a/tests/test_cdb_readcd.py
+++ b/tests/test_cdb_readcd.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_readcd import ReadCd
 from pyscsi.pyscsi.scsi_enum_command import mmc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbRead10Test(unittest.TestCase):

--- a/tests/test_cdb_readelementstatus.py
+++ b/tests/test_cdb_readelementstatus.py
@@ -13,7 +13,7 @@ from pyscsi.pyscsi.scsi_cdb_readelementstatus import ReadElementStatus
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbReadelementstatusTest(unittest.TestCase):

--- a/tests/test_cdb_reportpriority.py
+++ b/tests/test_cdb_reportpriority.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_report_priority import ReportPriority
 from pyscsi.pyscsi.scsi_enum_command import spc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbReportpriorityTest(unittest.TestCase):

--- a/tests/test_cdb_testunitready.py
+++ b/tests/test_cdb_testunitready.py
@@ -11,7 +11,7 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_testunitready import TestUnitReady
 from pyscsi.pyscsi.scsi_enum_command import sbc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbTestunitreadyTest(unittest.TestCase):

--- a/tests/test_cdb_write10.py
+++ b/tests/test_cdb_write10.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_write10 import Write10
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbWrite10Test(unittest.TestCase):

--- a/tests/test_cdb_write12.py
+++ b/tests/test_cdb_write12.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_write12 import Write12
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbWrite12Test(unittest.TestCase):

--- a/tests/test_cdb_write16.py
+++ b/tests/test_cdb_write16.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_write16 import Write16
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbWrite16Test(unittest.TestCase):

--- a/tests/test_cdb_writesame10.py
+++ b/tests/test_cdb_writesame10.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_writesame10 import WriteSame10
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbWritesame10Test(unittest.TestCase):

--- a/tests/test_cdb_writesame16.py
+++ b/tests/test_cdb_writesame16.py
@@ -12,7 +12,7 @@ from pyscsi.pyscsi.scsi_cdb_writesame16 import WriteSame16
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_ba_to_int
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class CdbWritesame16Test(unittest.TestCase):

--- a/tests/test_unmarshall_getlbastatus.py
+++ b/tests/test_unmarshall_getlbastatus.py
@@ -13,12 +13,12 @@ from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.pyscsi.scsi_enum_getlbastatus import P_STATUS
 from pyscsi.utils.converter import scsi_int_to_ba
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockGetLBAStatus(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0:8] = bytearray(8)
         pos = 8
 

--- a/tests/test_unmarshall_inquiry.py
+++ b/tests/test_unmarshall_inquiry.py
@@ -13,12 +13,12 @@ from pyscsi.pyscsi.scsi_cdb_inquiry import Inquiry
 from pyscsi.pyscsi.scsi_enum_command import sbc
 from pyscsi.utils.converter import scsi_int_to_ba
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockInquiryStandard(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x25  # QUAL:1 TYPE:5
         cmd.datain[1] = 0x80  # RMB:1
         cmd.datain[2] = 0x07  # VERSION:7
@@ -39,7 +39,7 @@ class MockInquiryStandard(MockDevice):
 
 class MockLBP(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x00  # QUAL:0 TYPE:0
         cmd.datain[1] = 0xb2  # logical block provisioning
         cmd.datain[2] = 0x00  #
@@ -52,7 +52,7 @@ class MockLBP(MockDevice):
 
 class MockUSN(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x00  # QUAL:0 TYPE:0
         cmd.datain[1] = 0x80  # unit serial number
         cmd.datain[2] = 0x00  #
@@ -62,7 +62,7 @@ class MockUSN(MockDevice):
 
 class MockDevId(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x00  # QUAL:0 TYPE:0
         cmd.datain[1] = 0x83  # device identifier
         cmd.datain[2] = 0x00
@@ -112,7 +112,7 @@ class MockDevId(MockDevice):
 
 class MockReferrals(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x00  # QUAL:0 TYPE:0
         cmd.datain[1] = 0xb3  # referrals
         cmd.datain[2] = 0x00  #
@@ -123,7 +123,7 @@ class MockReferrals(MockDevice):
 
 class MockExtendedInquiry(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 0x00   # QUAL:0 TYPE:0
         cmd.datain[1] = 0x86   # extended inquiry
         cmd.datain[2] = 0x00   #

--- a/tests/test_unmarshall_modesense10.py
+++ b/tests/test_unmarshall_modesense10.py
@@ -13,12 +13,12 @@ from pyscsi.pyscsi.scsi_cdb_modesense10 import ModeSense10
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_int_to_ba
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockModeSenseEAA(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 21    # mode data length
         cmd.datain[2] = 97    # medium type
         cmd.datain[3] = 98    # device specific parameter
@@ -40,7 +40,7 @@ class MockModeSenseEAA(MockDevice):
 
 class MockModeSenseControl(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[2] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[3] = 0x90  # device specific parameter
@@ -59,7 +59,7 @@ class MockModeSenseControl(MockDevice):
 
 class MockModeSenseControlExt1(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[2] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[3] = 0x90  # device specific parameter
@@ -76,7 +76,7 @@ class MockModeSenseControlExt1(MockDevice):
 
 class MockModeSenseDisconnect(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[2] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[3] = 0x90  # device specific parameter

--- a/tests/test_unmarshall_modesense6.py
+++ b/tests/test_unmarshall_modesense6.py
@@ -13,12 +13,12 @@ from pyscsi.pyscsi.scsi_cdb_modesense6 import ModeSense6
 from pyscsi.pyscsi.scsi_enum_command import spc
 from pyscsi.utils.converter import scsi_int_to_ba
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockModeSenseEAA(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 21  # mode data length
         cmd.datain[1] = 97  # medium type
         cmd.datain[2] = 98  # device specific parameter
@@ -39,7 +39,7 @@ class MockModeSenseEAA(MockDevice):
 
 class MockModeSenseControl(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[1] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[2] = 0x90  # device specific parameter
@@ -58,7 +58,7 @@ class MockModeSenseControl(MockDevice):
 
 class MockModeSenseControlExt1(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[1] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[2] = 0x90  # device specific parameter
@@ -75,7 +75,7 @@ class MockModeSenseControlExt1(MockDevice):
 
 class MockModeSenseDisconnect(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         cmd.datain[0] = 15    # mode data length
         cmd.datain[1] = 0     # medium type: BLOCK_DEVICE
         cmd.datain[2] = 0x90  # device specific parameter

--- a/tests/test_unmarshall_readcapacity10.py
+++ b/tests/test_unmarshall_readcapacity10.py
@@ -11,12 +11,12 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_readcapacity10 import ReadCapacity10
 from pyscsi.pyscsi.scsi_enum_command import sbc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockReadCapacity10(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         # lba
         cmd.datain[0:4] = [0x00, 0x01, 0x00, 0x00]
         # block size

--- a/tests/test_unmarshall_readcapacity16.py
+++ b/tests/test_unmarshall_readcapacity16.py
@@ -11,12 +11,12 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_readcapacity16 import ReadCapacity16
 from pyscsi.pyscsi.scsi_enum_command import sbc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockReadCapacity16(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         # lba
         cmd.datain[0:8] = [0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         # block size

--- a/tests/test_unmarshall_readcd.py
+++ b/tests/test_unmarshall_readcd.py
@@ -11,7 +11,7 @@ import unittest
 from pyscsi.pyscsi.scsi_cdb_readcd import ReadCd
 from pyscsi.pyscsi.scsi_enum_command import mmc
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 _SYNC = bytes([0x00, 0xff, 0xff, 0xff, 0xff, 0xff,
                0xff, 0xff, 0xff, 0xff, 0xff, 0x00])
@@ -20,7 +20,7 @@ _SYNC = bytes([0x00, 0xff, 0xff, 0xff, 0xff, 0xff,
 # Mock for a read of two sectors for SYNC and SubChannel type 2
 #
 class MockReadCD_SyncSubC(MockDevice):
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         # sync
         cmd.datain[0:12] = _SYNC
         # subchannel
@@ -37,7 +37,7 @@ class MockReadCD_SyncSubC(MockDevice):
 # Mock for a read of two sectors for SYNC and SectorHeader
 #
 class MockReadCD_SyncSH(MockDevice):
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         # sync
         cmd.datain[0:12] = _SYNC
         # subchannel

--- a/tests/test_unmarshall_readelementstatus.py
+++ b/tests/test_unmarshall_readelementstatus.py
@@ -13,12 +13,12 @@ from pyscsi.pyscsi.scsi_cdb_readelementstatus import ReadElementStatus
 from pyscsi.pyscsi.scsi_enum_command import smc
 from pyscsi.utils.converter import scsi_int_to_ba
 
-from .mock_device import MockDevice, MockSCSI
+from tests.mock_device import MockDevice, MockSCSI
 
 
 class MockReadElementStatus(MockDevice):
 
-    def execute(self, cmd):
+    def execute(self, cmd, en_raw_sense: bool=False):
         # element status header data
         data = bytearray(8)
         data[0:2] = scsi_int_to_ba(12, 2)  # first element address reported


### PR DESCRIPTION
with introduction of  en_raw_sense we need to
add that to the tests too. We might wanna refactor the way we construct tests so we dont DRY as we do for now.