### PR TITLE
Suppress PytestCollectionWarning for TestUnitReady class

### DIFF
--- a/pyscsi/pyscsi/scsi_cdb_testunitready.py
+++ b/pyscsi/pyscsi/scsi_cdb_testunitready.py
@@ -16,6 +16,7 @@ class TestUnitReady(SCSICommand):
     """
     A class to hold information from a testunitready command to a scsi device
     """
+    __test__ = False
     _cdb_bits = {'opcode': [0xff, 0], }
 
     def __init__(self,


### PR DESCRIPTION
Because of the naming of `TestUnitReady` it was inadvertently getting swept into `pytest `runs, generating then following warning.

```
python-scsi/pyscsi/pyscsi/scsi_cdb_testunitready.py:15: PytestCollectionWarning: cannot collect test class 'TestUnitReady' because it has a __init__ constructor (from: tests/test_cdb_te
stunitready.py)
    class TestUnitReady(SCSICommand):
```

This change does not change what tests are performed, just suppress the above warning.