### PR TITLE
Add additional exceptions for SCSI status

### DIFF
--- a/pyscsi/pyiscsi/iscsi_device.py
+++ b/pyscsi/pyiscsi/iscsi_device.py
@@ -104,6 +104,18 @@ class ISCSIDevice(metaclass=ExMETA):
             raise self.CheckCondition(cmd.sense)
         if task.status == scsi_enum_command.SCSI_STATUS.GOOD:
             return
+        if task.status == scsi_enum_command.SCSI_STATUS.RESERVATION_CONFLICT:
+            raise self.ReservationConflict()
+        if task.status == scsi_enum_command.SCSI_STATUS.TASK_ABORTED:
+            raise self.TaskAborted()
+        if task.status == scsi_enum_command.SCSI_STATUS.BUSY:
+            raise self.BusyStatus()
+        if task.status == scsi_enum_command.SCSI_STATUS.TASK_SET_FULL:
+            raise self.TaskSetFull()
+        if task.status == scsi_enum_command.SCSI_STATUS.ACA_ACTIVE:
+            raise self.ACAActive()
+        if task.status == scsi_enum_command.SCSI_STATUS.CONDITIONS_MET:
+            raise self.ConditionsMet()
         raise RuntimeError
 
     @property

--- a/pyscsi/pyscsi/scsi_exception.py
+++ b/pyscsi/pyscsi/scsi_exception.py
@@ -40,7 +40,31 @@ class SCSIDeviceExceptionMeta(type):
         class CheckCondition(SCSICheckCondition):
             pass
 
+        class ConditionsMet(Exception):
+            pass
+
+        class BusyStatus(Exception):
+            pass
+
+        class ReservationConflict(Exception):
+            pass
+
+        class TaskSetFull(Exception):
+            pass
+
+        class ACAActive(Exception):
+            pass
+
+        class TaskAborted(Exception):
+            pass
+
         attributes.update({"CheckCondition": CheckCondition})
+        attributes.update({"ConditionsMet": ConditionsMet})
+        attributes.update({"BusyStatus": BusyStatus})
+        attributes.update({"ReservationConflict": ReservationConflict})
+        attributes.update({"TaskSetFull": TaskSetFull})
+        attributes.update({"ACAActive": ACAActive})
+        attributes.update({"TaskAborted": TaskAborted})
 
         return type.__new__(mcs, cls, bases, attributes)
 


### PR DESCRIPTION
Wish to determine _why_ a SCSI command has failed, rather than just receiving a `RuntimeError`.

(For completeness followed existing pattern for all `SCSI_STATUS` values.)