### PR TITLE
Fix sense data for iSCSI CheckCondition

### DIFF
--- a/pyscsi/pyscsi/scsi_sense.py
+++ b/pyscsi/pyscsi/scsi_sense.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from pyscsi.utils.converter import decode_bits
+from pyscsi.utils.converter import decode_bits, encode_dict
 
 #
 # SPC4 4.5 Sense Data
@@ -1043,4 +1043,20 @@ class SCSICheckCondition(Exception):
     def unmarshall_desc_format_sense_data(data):
         result = {}
         decode_bits(data, SCSICheckCondition._desc_format_sdata_bits, result)
+        return result
+
+    @staticmethod
+    def marshall_sense_data(data):
+        if data["response_code"] == SENSE_FORMAT_CURRENT_FIXED:
+            result = bytearray(18)
+            encode_dict(data, SCSICheckCondition._fixed_format_sdata_bits, result)
+        elif data["response_code"] == SENSE_FORMAT_CURRENT_DESCRIPTOR:
+            result = bytearray(8)
+            encode_dict(data, SCSICheckCondition._desc_format_sdata_bits, result)
+        else:
+            raise ValueError(
+                "Invalid response code: %d (0x%x)",
+                data["response_code"],
+                data["response_code"],
+            )
         return result


### PR DESCRIPTION
Currently raising `CheckCondition` is broken for iscsi as the sense data is missing.
```
  ...
  File "/home/brian/tmp/python-scsi/pyscsi/pyscsi/scsi.py", line 110, in execute
    self.device.execute(cmd, en_raw_sense=en_raw_sense)
  File "/home/brian/tmp/python-scsi/pyscsi/pyiscsi/iscsi_device.py", line 104, in execute
    raise self.CheckCondition(cmd.sense)
  File "/home/brian/tmp/python-scsi/pyscsi/pyscsi/scsi_sense.py", line 997, in __init__
    self.valid = sense[0] & 0x80
TypeError: 'NoneType' object is not subscriptable
```
Earlier I opened pull request to _cython-iscsi_ that this pull request **requires**.  However, since (AFAIK) _python-scsi_ and _cython-iscsi_ have the same maintainers I thought I'd make both PRs visible at the same time.

See:

- https://github.com/python-scsi/cython-iscsi/pull/7

With changes from **both** PRs in place the `CheckCondition` _does_ get raised properly
```
  ...
    r = s.read16(1024000000, 2)
  File "/home/brian/bmeagherix/python-scsi/pyscsi/pyscsi/scsi.py", line 373, in read16
    self.execute(cmd)
  File "/home/brian/bmeagherix/python-scsi/pyscsi/pyscsi/scsi.py", line 112, in execute
    raise e
  File "/home/brian/bmeagherix/python-scsi/pyscsi/pyscsi/scsi.py", line 110, in execute
    self.device.execute(cmd, en_raw_sense=en_raw_sense)
  File "/home/brian/bmeagherix/python-scsi/pyscsi/pyiscsi/iscsi_device.py", line 115, in execute
    raise self.CheckCondition(cmd.sense)
pyscsi.pyscsi.scsi_exception.CheckCondition: Check Condition: Illegal Request(0x05) ASC+Q:LOGICAL BLOCK ADDRESS OUT OF RANGE(0x2100)
```

