### PR TITLE
Add support for SYNCHRONIZE CACHE (10) and (16)

### DIFF
--- a/pyscsi/pyscsi/__init__.py
+++ b/pyscsi/pyscsi/__init__.py
@@ -25,6 +25,8 @@ __all__ = [
     "scsi_cdb_readdiscinformation",
     "scsi_cdb_report_luns",
     "scsi_cdb_report_priority",
+    "scsi_cdb_synchronize_cache10",
+    "scsi_cdb_synchronize_cache16",
     "scsi_cdb_testunitready",
     "scsi_cdb_write10",
     "scsi_cdb_write12",

--- a/pyscsi/pyscsi/scsi.py
+++ b/pyscsi/pyscsi/scsi.py
@@ -38,6 +38,8 @@ from pyscsi.pyscsi.scsi_cdb_readelementstatus import ReadElementStatus
 from pyscsi.pyscsi.scsi_cdb_report_luns import ReportLuns
 from pyscsi.pyscsi.scsi_cdb_report_priority import ReportPriority
 from pyscsi.pyscsi.scsi_cdb_report_target_port_groups import ReportTargetPortGroups
+from pyscsi.pyscsi.scsi_cdb_synchronize_cache10 import SynchronizeCache10
+from pyscsi.pyscsi.scsi_cdb_synchronize_cache16 import SynchronizeCache16
 from pyscsi.pyscsi.scsi_cdb_testunitready import TestUnitReady
 from pyscsi.pyscsi.scsi_cdb_write10 import Write10
 from pyscsi.pyscsi.scsi_cdb_write12 import Write12
@@ -471,6 +473,46 @@ class SCSI(object):
         """
         opcode = self.device.opcodes.MOVE_MEDIUM
         cmd = MoveMedium(opcode, xfer, source, dest, **kwargs)
+        self.execute(cmd)
+        return cmd
+
+    def synchronizecache10(self, lba, numblks, **kwargs):
+        """
+        Returns a SynchronizeCache10 Instance
+
+        :param lba: Logical Block Address to write to
+        :param numblks: number of logical blocks that shall be
+                        synchronized, starting with the logical
+                        block referenced by the lba
+        :param kwargs: a dict with key/value pairs
+                       immed = 0, do not return status until the
+                                  synchronize cache operation has
+                                  been completed.
+                       group = 0, Group Number
+        :return: a SynchronizeCache10 instance
+        """
+        opcode = self.device.opcodes.SYNCHRONIZE_CACHE_10
+        cmd = SynchronizeCache10(opcode, lba, numblks, **kwargs)
+        self.execute(cmd)
+        return cmd
+
+    def synchronizecache16(self, lba, numblks, **kwargs):
+        """
+        Returns a SynchronizeCache16 Instance
+
+        :param lba: Logical Block Address to write to
+        :param numblks: number of logical blocks that shall be
+                        synchronized, starting with the logical
+                        block referenced by the lba
+        :param kwargs: a dict with key/value pairs
+                       immed = 0, do not return status until the
+                                  synchronize cache operation has
+                                  been completed.
+                       group = 0, Group Number
+        :return: a SynchronizeCache16 instance
+        """
+        opcode = self.device.opcodes.SYNCHRONIZE_CACHE_16
+        cmd = SynchronizeCache16(opcode, lba, numblks, **kwargs)
         self.execute(cmd)
         return cmd
 

--- a/pyscsi/pyscsi/scsi_cdb_synchronize_cache10.py
+++ b/pyscsi/pyscsi/scsi_cdb_synchronize_cache10.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+# Copyright (C) 2024 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pyscsi.pyscsi.scsi_command import SCSICommand
+
+#
+# SCSI SYNCHRONIZE CACHE 10 command and definitions
+#
+# See SBC-4 5.33 SYNCHRONIZE CACHE (10) command
+#
+
+
+class SynchronizeCache10(SCSICommand):
+    """
+    A class to send a Synchronize Cache (10) command to a scsi device
+    """
+
+    _cdb_bits = {
+        "opcode": [0xFF, 0],
+        "immed": [0x02, 1],
+        "lba": [0xFFFFFFFF, 2],
+        "group": [0x1F, 6],
+        "numblks": [0xFFFF, 7],
+    }
+
+    def __init__(self, opcode, lba, numblks, immed=0, group=0):
+        """
+        initialize a new instance
+
+        :param opcode: a OpCode instance
+        :param lba: Logical Block Address
+        :param numblks: transfer length
+        :param immed=0:
+        :param group=0:
+        """
+        SCSICommand.__init__(self, opcode, 0, 0)
+        self.cdb = self.build_cdb(
+            opcode=self.opcode.value,
+            lba=lba,
+            numblks=numblks,
+            immed=immed,
+            group=group,
+        )

--- a/pyscsi/pyscsi/scsi_cdb_synchronize_cache16.py
+++ b/pyscsi/pyscsi/scsi_cdb_synchronize_cache16.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+# Copyright (C) 2024 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pyscsi.pyscsi.scsi_command import SCSICommand
+
+#
+# SCSI SYNCHRONIZE CACHE 16 command and definitions
+#
+# See SBC-4 5.34 SYNCHRONIZE CACHE (16) command
+#
+
+
+class SynchronizeCache16(SCSICommand):
+    """
+    A class to send a Synchronize Cache (16) command to a scsi device
+    """
+
+    _cdb_bits = {
+        "opcode": [0xFF, 0],
+        "immed": [0x02, 1],
+        "lba": [0xFFFFFFFFFFFFFFFF, 2],
+        "numblks": [0xFFFFFFFF, 10],
+        "group": [0x1F, 14],
+    }
+
+    def __init__(self, opcode, lba, numblks, immed=0, group=0):
+        """
+        initialize a new instance
+
+        :param opcode: a OpCode instance
+        :param lba: Logical Block Address
+        :param numblks: transfer length
+        :param immed=0:
+        :param group=0:
+        """
+        SCSICommand.__init__(self, opcode, 0, 0)
+        self.cdb = self.build_cdb(
+            opcode=self.opcode.value,
+            lba=lba,
+            numblks=numblks,
+            immed=immed,
+            group=group,
+        )

--- a/tests/test_cdb_synchronize_cache10.py
+++ b/tests/test_cdb_synchronize_cache10.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+
+# Copyright (C) 2024 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from pyscsi.pyscsi.scsi_cdb_synchronize_cache10 import SynchronizeCache10
+from pyscsi.pyscsi.scsi_enum_command import sbc
+from pyscsi.utils.converter import scsi_ba_to_int
+from tests.mock_device import MockDevice, MockSCSI
+
+
+class CdbSynchronizeCache10Test(unittest.TestCase):
+    def test_main(self):
+        with MockSCSI(MockDevice(sbc)) as s:
+            s.blocksize = 512
+
+            sc = s.synchronizecache10(1024, 25)
+            cdb = sc.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.SYNCHRONIZE_CACHE_10.value)
+            self.assertEqual(cdb[1], 0)
+            self.assertEqual(scsi_ba_to_int(cdb[2:6]), 1024)
+            self.assertEqual(cdb[6], 0)
+            self.assertEqual(scsi_ba_to_int(cdb[7:9]), 25)
+            self.assertEqual(cdb[9], 0)
+            cdb = sc.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.SYNCHRONIZE_CACHE_10.value)
+            self.assertEqual(cdb["immed"], 0)
+            self.assertEqual(cdb["lba"], 1024)
+            self.assertEqual(cdb["group"], 0)
+            self.assertEqual(cdb["numblks"], 25)
+
+            d = SynchronizeCache10.unmarshall_cdb(SynchronizeCache10.marshall_cdb(cdb))
+            self.assertEqual(d, cdb)
+
+            sc = s.synchronizecache10(65536, 27, immed=1, group=19)
+            cdb = sc.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.SYNCHRONIZE_CACHE_10.value)
+            self.assertEqual(cdb[1], 0x02)
+            self.assertEqual(scsi_ba_to_int(cdb[2:6]), 65536)
+            self.assertEqual(cdb[6], 0x13)
+            self.assertEqual(scsi_ba_to_int(cdb[7:9]), 27)
+            self.assertEqual(cdb[9], 0)
+            cdb = sc.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.SYNCHRONIZE_CACHE_10.value)
+            self.assertEqual(cdb["immed"], 1)
+            self.assertEqual(cdb["lba"], 65536)
+            self.assertEqual(cdb["group"], 19)
+            self.assertEqual(cdb["numblks"], 27)
+
+            d = SynchronizeCache10.unmarshall_cdb(SynchronizeCache10.marshall_cdb(cdb))
+            self.assertEqual(d, cdb)

--- a/tests/test_cdb_synchronize_cache16.py
+++ b/tests/test_cdb_synchronize_cache16.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+# Copyright (C) 2024 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from pyscsi.pyscsi.scsi_cdb_synchronize_cache16 import SynchronizeCache16
+from pyscsi.pyscsi.scsi_enum_command import sbc
+from pyscsi.utils.converter import scsi_ba_to_int
+from tests.mock_device import MockDevice, MockSCSI
+
+
+class CdbSynchronizeCache16Test(unittest.TestCase):
+    def test_main(self):
+        with MockSCSI(MockDevice(sbc)) as s:
+            s.blocksize = 512
+
+            sc = s.synchronizecache16(1024, 25)
+            cdb = sc.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.SYNCHRONIZE_CACHE_16.value)
+            self.assertEqual(cdb[1], 0)
+            self.assertEqual(scsi_ba_to_int(cdb[2:10]), 1024)
+            self.assertEqual(scsi_ba_to_int(cdb[10:14]), 25)
+            self.assertEqual(cdb[14], 0)
+            cdb = sc.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.SYNCHRONIZE_CACHE_16.value)
+            self.assertEqual(cdb["immed"], 0)
+            self.assertEqual(cdb["lba"], 1024)
+            self.assertEqual(cdb["group"], 0)
+            self.assertEqual(cdb["numblks"], 25)
+
+            d = SynchronizeCache16.unmarshall_cdb(SynchronizeCache16.marshall_cdb(cdb))
+            self.assertEqual(d, cdb)
+
+            sc = s.synchronizecache16(65536, 27, immed=1, group=19)
+            cdb = sc.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.SYNCHRONIZE_CACHE_16.value)
+            self.assertEqual(cdb[1], 0x02)
+            self.assertEqual(scsi_ba_to_int(cdb[2:10]), 65536)
+            self.assertEqual(scsi_ba_to_int(cdb[10:14]), 27)
+            self.assertEqual(cdb[14], 0x13)
+            cdb = sc.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.SYNCHRONIZE_CACHE_16.value)
+            self.assertEqual(cdb["immed"], 1)
+            self.assertEqual(cdb["lba"], 65536)
+            self.assertEqual(cdb["group"], 19)
+            self.assertEqual(cdb["numblks"], 27)
+
+            d = SynchronizeCache16.unmarshall_cdb(SynchronizeCache16.marshall_cdb(cdb))
+            self.assertEqual(d, cdb)


### PR DESCRIPTION
Add support for `SYNCHRONIZE CACHE (10)` and `SYNCHRONIZE CACHE (16)` as described in SBC-4
-  5.33 SYNCHRONIZE CACHE (10) command
-  5.34 SYNCHRONIZE CACHE (16) command

Tests are included.