### PR TITLE
Add "NO ADDITIONAL SENSE INFORMATION" to sense_ascq_dict

### DIFF
--- a/pyscsi/pyscsi/scsi_sense.py
+++ b/pyscsi/pyscsi/scsi_sense.py
@@ -39,6 +39,7 @@ vendor_specific_sense_asc = vendor_specific_sense_ascq = range(0x80, 0xFF + 1)
 
 # dict with additional sense data
 sense_ascq_dict = {
+    0x0000: "NO ADDITIONAL SENSE INFORMATION",
     0x0001: "FILEMARK DETECTED",
     0x0002: "END-OF-PARTITION/MEDIUM DETECTED",
     0x0003: "SETMARK DETECTED",


### PR DESCRIPTION
Found that "NO ADDITIONAL SENSE INFORMATION" was missing from `sense_ascq_dict`.  Add it to prevent breakage (e.g. with Data Protect CHECK CONDITION).

FWIW, this is the **first** entry in the table _SPC-5 F.2 Additional sense codes_